### PR TITLE
Upgrade to latest Rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       commander
       kramdown
       nokogiri
-      rubyzip (~> 1.0.0)
+      rubyzip
       textstats
       typogruby
 
@@ -20,7 +20,7 @@ GEM
     builder (3.2.2)
     childprocess (0.5.3)
       ffi (~> 1.0, >= 1.0.11)
-    commander (4.2.0)
+    commander (4.2.1)
       highline (~> 1.6.11)
     coveralls (0.7.0)
       multi_json (~> 1.3)
@@ -40,14 +40,14 @@ GEM
     gherkin (2.12.2)
       multi_json (~> 1.3)
     highline (1.6.21)
-    kramdown (1.4.1)
+    kramdown (1.5.0)
     mime-types (2.3)
-    mini_portile (0.6.0)
+    mini_portile (0.6.1)
     multi_json (1.10.1)
     multi_test (0.1.1)
     netrc (0.7.7)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.4.1)
+      mini_portile (~> 0.6.0)
     rake (10.3.2)
     rest-client (1.7.2)
       mime-types (>= 1.16, < 3.0)
@@ -65,7 +65,7 @@ GEM
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
     rubypants (0.2.0)
-    rubyzip (1.0.0)
+    rubyzip (1.1.6)
     simplecov (0.9.0)
       docile (~> 1.1.0)
       multi_json
@@ -76,7 +76,7 @@ GEM
     textstats (0.0.2)
     thor (0.19.1)
     tins (1.3.1)
-    typogruby (1.0.16)
+    typogruby (1.0.17)
       rubypants
     yard (0.8.7.4)
 

--- a/rpub.gemspec
+++ b/rpub.gemspec
@@ -38,7 +38,7 @@ EOS
   # Dependencies
   s.add_runtime_dependency 'typogruby'
   s.add_runtime_dependency 'kramdown'
-  s.add_runtime_dependency 'rubyzip', '~> 1.0.0'
+  s.add_runtime_dependency 'rubyzip'
   s.add_runtime_dependency 'builder'
   s.add_runtime_dependency 'nokogiri'
   s.add_runtime_dependency 'textstats'


### PR DESCRIPTION
This will use the new Zip API that is found in Rubyzip. We do not need the `zip` library at all. Something probably went wrong in #14.

Closes #15, #17
