### PR TITLE
Changed FilesystemSource.read to use open-uri.

### DIFF
--- a/lib/rpub/filesystem_source.rb
+++ b/lib/rpub/filesystem_source.rb
@@ -1,9 +1,10 @@
+require 'open-uri'
 module Rpub
   module FilesystemSource
     module_function
 
     def read(filename)
-      File.read(filename)
+      open(filename) { |f| f.read }
     end
 
     def exists?(filename)


### PR DESCRIPTION
By switching from File.read to open-uri's open, support is added for remote files.  Now markdown files with image links and other remote links should generate properly.  I have only tested with a few sample files, but I immediately saw an improvement in the generation of valid epub files from source documents that threw error messages before. 

Existing functionality is still supported - all test cases passed locally. 
